### PR TITLE
fix PYBIND11_VTK_TYPECASTER macro and supply typecasters for vtkRende…

### DIFF
--- a/dynamic/wrappers/visualization/VtkScene2.cppwg.cpp
+++ b/dynamic/wrappers/visualization/VtkScene2.cppwg.cpp
@@ -7,12 +7,29 @@
 #include "SmartPointers.hpp"
 #include "UblasIncludes.hpp"
 #include "VtkScene.hpp"
+#include <vtkOpenGLRenderer.h>
+#include <vtkUnsignedCharArray.h>
+#include <vtkSmartPointer.h>
+#include "PythonObjectConverters.hpp"
 
 #include "VtkScene2.cppwg.hpp"
 
 namespace py = pybind11;
 typedef VtkScene<2 > VtkScene2;
 PYBIND11_DECLARE_HOLDER_TYPE(T, boost::shared_ptr<T>);
+PYBIND11_DECLARE_HOLDER_TYPE(T, vtkSmartPointer<T>);
+PYBIND11_VTK_TYPECASTER(vtkRenderer);
+PYBIND11_VTK_TYPECASTER(vtkOpenGLRenderer);
+PYBIND11_VTK_TYPECASTER(vtkUnsignedCharArray);
+
+
+// Only needed if the type's `.get()` goes by another name
+namespace PYBIND11_NAMESPACE { namespace detail {
+    template <typename T>
+    struct holder_helper<vtkSmartPointer<T>> { // <-- specialization
+        static const T *get(const vtkSmartPointer<T> &p) { return p.Get(); }
+    };
+}}
 
 class VtkScene2_Overloads : public VtkScene2{
     public:

--- a/src/PythonObjectConverters.hpp
+++ b/src/PythonObjectConverters.hpp
@@ -151,7 +151,7 @@ namespace pybind11 { namespace detail {                                 \
   protected:                                                            \
 VTK_OBJ *value;                                                         \
 public:                                                                 \
-static PYBIND11_DESCR name() { return type_descr(_(#VTK_OBJ)); }        \
+static constexpr auto name =_(#VTK_OBJ);        \
 operator VTK_OBJ *() { return value; }                                  \
 operator VTK_OBJ &() { return *value; }                                 \
 template <typename _T> using cast_op_type =                             \

--- a/src/python/chaste/visualization/fortests.py
+++ b/src/python/chaste/visualization/fortests.py
@@ -151,7 +151,7 @@ if PYCHASTE_CAN_IMPORT_IPYTHON:
                     writer.SetWriteToMemory(1)
                     writer.SetInputConnection(windowToImageFilter.GetOutputPort())
                     writer.Write()
-                    data = str(buffer(writer.GetResult()))
+                    data = memoryview(writer.GetResult())
                      
                     return Image(data)
                 


### PR DESCRIPTION
Closes #1 

Tested using Ubuntu 22.04, VTK 7.1.1 and python 3.10.

The PR includes a fix to the PYBIND11_VTK_TYPECASTER macro and then uses this macro to register vtkRenderer and vtkOpenGLRenderer with pybind. Python notebooks using visualisation now correctly display a rendering window, although the window doesn't show any output so this needs further investigation.