### PR TITLE
Switch docker to jupyterlab

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       
     steps:
     - name: checkout Chaste repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Chaste/Chaste
         ref: develop
@@ -27,7 +27,7 @@ jobs:
         submodules: recursive
 
     - name: checkout PyChaste repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: Chaste/projects/PyChaste
         submodules: recursive

--- a/.github/workflows/conda-build-linux.yml
+++ b/.github/workflows/conda-build-linux.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: build conda package
       run: ./build-py310.sh

--- a/.github/workflows/conda-build-linux.yml
+++ b/.github/workflows/conda-build-linux.yml
@@ -18,7 +18,7 @@ jobs:
       working-directory: infra/conda/chaste
       
     - name: upload conda package artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pychaste-conda
         path: infra/conda/chaste/build_artifacts/linux-64

--- a/.github/workflows/update-pychaste-tutorials.yml
+++ b/.github/workflows/update-pychaste-tutorials.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
       
@@ -31,7 +31,7 @@ jobs:
       working-directory: infra
 
     - name: upload archive files
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pychaste-tutorials-markdown
         path: doc/tutorials/*.md
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Download pychaste-tutorials-markdown
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pychaste-tutorials-markdown
 

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -13,8 +13,9 @@ RUN apt-get update && \
     rm -rf /tmp/*
 
 USER $MAMBA_USER
-RUN micromamba install -y -n base -c pychaste -c conda-forge -c bioconda chaste boost-cpp=1.74 notebook && \
+RUN micromamba install -y -n base -c pychaste -c conda-forge -c bioconda chaste boost-cpp=1.74 jupyterlab && \
     micromamba clean --all --yes && \
+    rm -rf $HOME/micromamba/pkgs/* && \
     rm -rf /opt/conda/pkgs/*
 
-CMD xvfb-run --server-args="-screen 0 1024x768x24" jupyter notebook --port=8888 --no-browser --ip=0.0.0.0
+CMD xvfb-run --server-args="-screen 0 1024x768x24" jupyter lab --port=8888 --no-browser --ip=0.0.0.0

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -1,4 +1,12 @@
 FROM mambaorg/micromamba:1.5-jammy
+LABEL maintainer="Kwabena N. Amponsah <kwabenantim@gmail.com>" \
+    author.orcid="https://orcid.org/0000-0002-7506-9040" \
+    org.opencontainers.image.authors="Kwabena N. Amponsah" \
+    org.opencontainers.image.url="https://github.com/Chaste/PyChaste" \
+    org.opencontainers.image.licenses="3-Clause BSD" \
+    org.opencontainers.image.title="PyChaste Docker Image" \
+    org.opencontainers.image.description="PyChaste: Python Bindings for Chaste" \
+    org.opencontainers.image.documentation="https://chaste.github.io/pychaste/"
 
 USER root
 RUN apt-get update && \

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -1,3 +1,6 @@
+# docker build -t pychaste .
+# docker run -it --init --rm -p 8888:8888 pychaste
+
 FROM mambaorg/micromamba:1.5-jammy
 LABEL maintainer="Kwabena N. Amponsah <kwabenantim@gmail.com>" \
     author.orcid="https://orcid.org/0000-0002-7506-9040" \

--- a/infra/docker/README.md
+++ b/infra/docker/README.md
@@ -1,15 +1,16 @@
 # How to build the docker image
+The `pychaste` docker image is on the channel `chaste` on Docker Hub. This directory contains the Dockerfile for building the image. The guidance below assumes that [Docker](https://www.docker.com) has been installed. Docker commands may need to be prefixed with `sudo` depending on how Docker is set up on your system.
 
-The `pychaste` docker image is on the channel `chaste` on the Docker Hub. This directory contains the Dockerfile for building the image. Assuming [Docker](https://www.docker.com) is set up, it can be built by running:
+The image can be built by running:
 
 ```bash
-[sudo] docker build -t pychaste .
+docker build -t pychaste .
 ```
 
 ## Working with the local image
 
 ```bash
-[sudo] docker run --init -it -p 8888:8888 pychaste
+docker run -it --init --rm -p 8888:8888 pychaste
 ```
 
 Then go to [http://127.0.0.1:8888](http://127.0.0.1:8888) in a web browser.
@@ -19,13 +20,13 @@ If you are happy with the package it can be tagged and uploaded to Docker Hub.
 To find the image id, run:
 
 ```bash
-[sudo] docker images
+docker images
 ```
 
 To tag the image with the `latest` tag and upload it to Docker Hub:
 
 ```bash
-[sudo] docker tag <image_id> chaste/pychaste:latest
+docker tag <image_id> chaste/pychaste:latest
 docker login
 docker push chaste/pychaste:latest
 ```

--- a/infra/docker/README.md
+++ b/infra/docker/README.md
@@ -6,6 +6,15 @@ The `pychaste` docker image is on the channel `chaste` on the Docker Hub. This d
 [sudo] docker build -t pychaste .
 ```
 
+## Working with the local image
+
+```bash
+[sudo] docker run --init -it -p 8888:8888 pychaste
+```
+
+Then go to [http://127.0.0.1:8888](http://127.0.0.1:8888) in a web browser.
+
+## Uploading the image
 If you are happy with the package it can be tagged and uploaded to Docker Hub.
 To find the image id, run:
 
@@ -20,12 +29,3 @@ To tag the image with the `latest` tag and upload it to Docker Hub:
 docker login
 docker push chaste/pychaste:latest
 ```
-
-## Working with the local image
-
-```bash
-[sudo] docker run --init -it -p 8888:8888 pychaste
-```
-
-Then go to [http://127.0.0.1:8888](http://127.0.0.1:8888) in a web browser.
-

--- a/infra/docker/README.md
+++ b/infra/docker/README.md
@@ -27,5 +27,5 @@ docker push chaste/pychaste:latest
 [sudo] docker run --init -it -p 8888:8888 pychaste
 ```
 
-Then go to [http://localhost::8888](http://localhost::8888) in a web browser.
+Then go to [http://127.0.0.1:8888](http://127.0.0.1:8888) in a web browser.
 


### PR DESCRIPTION
**Summary**
Switch from `notebook` to more modern `jupyterlab` in pychaste docker image.


**Related Issues**
* #28 